### PR TITLE
clean up and add demo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,8 @@
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html lang="en">
+  <head>
+    <title>prism-element demo</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="../../paper-styles/demo-pages.html">
+    <link rel="import" href="prism-demo.html">
+  </head>
+  <body>
+    <div class="vertical-section-container centered">
+      <h4><code>p { color: blue; }</code> with lang="css"</h4>
+      <div class="vertical-section">
+        <prism-demo code="p { color: blue; }" lang="css"></prism-demo>
+      </div>
+      <h4><code>&lt;style&gt;p { color: blue; }&lt;/style&gt;</code> with automatic language detection</h4>
+      <div class="vertical-section">
+        <prism-demo code="<style>p { color: blue; }</style>"></prism-demo>
+      </div>
+
+      <h4><code>&lt;p&gt; class="batman"&gt;&lt;/p&gt;</code> with automatic language detection</h4>
+      <div class="vertical-section">
+        <prism-demo code="<p class=batman></p>" lang="html"></prism-demo>
+      </div>
+  </div>
+  </body>
+</html>

--- a/demo/prism-demo.html
+++ b/demo/prism-demo.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link href="../prism-highlighter.html" rel="import">
+
+<dom-module id='prism-demo'>
+  <template>
+    <style>
+      pre {
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+
+    <prism-highlighter></prism-highlighter>
+    <pre id="output"></pre>
+
+  </template>
+
+  <script>
+    Polymer({
+      is: 'prism-demo',
+
+      properties: {
+        code: {
+          type: String,
+          observer: '_render'
+        },
+
+        lang: {
+          type: String
+        }
+      },
+
+      attached: function() {
+        this._render();
+      },
+
+      _render: function() {
+        this.$.output.innerHTML = this.highlight(this.code, this.lang);
+      },
+
+      highlight: function(code, lang) {
+        return this.fire('syntax-highlight', {code: code, lang: lang}).detail.code;
+      }
+    });
+  </script>
+
+</dom-module>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>prism-element</title>
+
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+
+<iron-component-page src="prism-highlighter.html"></iron-component-page>
+
+</body>
+</html>


### PR DESCRIPTION
Adds a demo, which fixes #7, and also brings this element into the future (no `index.html` was bad news bears):
<img width="535" alt="screen shot 2015-10-30 at 12 58 41 am" src="https://cloud.githubusercontent.com/assets/1369170/10840910/9c01284c-7ea1-11e5-88e2-d97ee5629067.png">

I will add tests in a separate PR. One step at a time.
