### PR TITLE
Add demo and element tags for docs

### DIFF
--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -25,7 +25,7 @@ containing the source to highlight. The event detail can optionally contain a
 
 This flow is supported by [`<marked-element>`](https://github.com/PolymerElements/marked-element).
 
-@element prisim-highlighter
+@element prism-highlighter
 @demo demo/index.html
 -->
 <script>

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -24,6 +24,9 @@ containing the source to highlight. The event detail can optionally contain a
 `lang` property, containing a string like `"html"`, `"js"`, etc.
 
 This flow is supported by [`<marked-element>`](https://github.com/PolymerElements/marked-element).
+
+@element prisim-hilighter
+@demo demo/index.html
 -->
 <script>
 (function() {

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -25,7 +25,7 @@ containing the source to highlight. The event detail can optionally contain a
 
 This flow is supported by [`<marked-element>`](https://github.com/PolymerElements/marked-element).
 
-@element prisim-hilighter
+@element prisim-highlighter
 @demo demo/index.html
 -->
 <script>


### PR DESCRIPTION
Missing the little demo button thing in [the docs](https://elements.polymer-project.org/elements/prism-element). :(
