### PR TITLE
Fixed broken demo in prism-element as seen in polymer-element-catalog

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,7 @@
   "main": "prism-highlighter.html",
   "ignore": [
     "/.*",
-    "/test/",
-    "/demo/"
+    "/test/"
   ],
   "dependencies": {
     "prism": "*",

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <prism-demo code="<style>p { color: blue; }</style>"></prism-demo>
       </div>
 
-      <h4><code>&lt;p&gt; class="batman"&gt;&lt;/p&gt;</code> with automatic language detection</h4>
+      <h4><code>&lt;p class="batman"&gt;&lt;/p&gt;</code> with automatic language detection</h4>
       <div class="vertical-section">
         <prism-demo code="<p class=batman></p>" lang="html"></prism-demo>
       </div>


### PR DESCRIPTION
Absense of 'demo' folder in installed version of prism-element resulted
in a broken demo link in polymer-element-catalog for prism-element.
This was reported as https://github.com/PolymerElements/prism-element/issues/19
though I decided to fix this after encountering the broken link independently.
