### PR TITLE
Add data binding

### DIFF
--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -48,7 +48,8 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
       },
       highlighted: {
         type: String,
-        computed: '_computeHighlighted(code, lang)'
+        computed: '_computeHighlighted(code, lang)',
+        notify: true
       }
     },
 

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -27,7 +27,7 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
 You may also use this element with data-binding like so:
 
 ```html
-<prism-element code="{{source}}" highlighted="{{result}}"></prism-element>
+<prism-highlighter code="{{source}}" highlighted="{{result}}"></prism-highlighter>
 ```
 
 @element prism-highlighter

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -24,6 +24,12 @@ containing the source to highlight. The event detail can optionally contain a
 
 This flow is supported by [`<marked-element>`](https://github.com/PolymerElements/marked-element).
 
+You may also use this element with data-binding like so:
+
+```html
+<prism-element code="{{source}}" highlighted="{{result}}"></prism-element>
+```
+
 @element prism-highlighter
 @demo demo/index.html
 -->
@@ -39,17 +45,27 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
     is: 'prism-highlighter',
 
     properties: {
+      /**
+       * The source to be highlighted
+       */
       code: {
         type: String
       },
+      /**
+       * An optional language hint, such as `js`
+       */
       lang: {
         type: String,
         value: null
       },
+      /**
+       * The highlighted source code
+       */
       highlighted: {
         type: String,
         computed: '_computeHighlighted(code, lang)',
-        notify: true
+        notify: true,
+        readOnly: true
       }
     },
 

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -38,16 +38,54 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
 
     is: 'prism-highlighter',
 
+    properties: {
+      code: {
+        type: String
+      },
+      lang: {
+        type: String,
+        value: null
+      },
+      highlighted: {
+        type: String,
+        computed: '_computeHighlighted(code, lang)'
+      }
+    },
+
     ready: function() {
       this._handler = this._highlight.bind(this);
     },
 
     attached: function() {
-      (this.parentElement || this.parentNode.host).addEventListener(HIGHLIGHT_EVENT, this._handler);
+      var host = this.parentElement || (this.parentNode && this.parentNode.host);
+      if(host) {
+        host.addEventListener(HIGHLIGHT_EVENT, this._handler);
+      }
     },
 
     detached: function() {
-      (this.parentElement || this.parentNode.host).removeEventListener(HIGHLIGHT_EVENT, this._handler);
+      var host = this.parentElement || (this.parentNode && this.parentNode.host);
+      if(host) {
+        host.removeEventListener(HIGHLIGHT_EVENT, this._handler);
+      }
+    },
+
+    /**
+     * Highlight the given code with an
+     * optional language hint specified.
+     *
+     * @param {string} code The source being highlighted
+     * @param {string=} lang A language hint (e.g. "js").
+     */
+    highlight: function(code, lang) {
+      return Prism.highlight(code, this._detectLang(code, lang));
+    },
+
+    _computeHighlighted: function(code, lang) {
+      if(!code) {
+        return;
+      }
+      return this.highlight(code, lang);
     },
 
     /**
@@ -64,14 +102,14 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
       event.stopPropagation();
 
       var detail = event.detail;
-      detail.code = Prism.highlight(detail.code, this._detectLang(detail.code, detail.lang));
+      detail.code = this.highlight(detail.code, detail.lang);
     },
 
     /**
      * Picks a Prism formatter based on the `lang` hint and `code`.
      *
      * @param {string} code The source being highlighted.
-     * @param {string=} lang A language hint (e.g. ````LANG`).
+     * @param {string=} lang A language hint (e.g. "js").
      * @return {!prism.Lang}
      */
     _detectLang: function(code, lang) {

--- a/test/prism-element.html
+++ b/test/prism-element.html
@@ -38,6 +38,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="simple-binding">
+      <template>
+        <prism-highlighter></prism-highlighter>
+      </template>
+    </test-fixture>
+
     <script>
       suite('<prism-highlighter>', function() {
           var el;
@@ -58,6 +64,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             };
 
             el.fire('syntax-highlight', ev);
+
+            expect(Prism.highlight.calledWithExactly('<foo>', Prism.languages.markup))
+              .to.equal(true);
+          });
+
+          test('highlights on highlight call', function() {
+            var el = fixture('simple-binding');
+
+            el.highlight('<foo>', 'markup');
 
             expect(Prism.highlight.calledWithExactly('<foo>', Prism.languages.markup))
               .to.equal(true);
@@ -152,6 +167,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
                 expect(Prism.highlight.calledWithExactly('return;', Prism.languages.clike))
                   .to.equal(true);
+              });
+          });
+
+          suite('can be used via data-binding', function() {
+              setup(function() {
+                el = fixture('simple-binding');
+              });
+
+              test('highlights given code', function() {
+                expect(el.highlighted).to.equal(undefined);
+                el.code = 'return;';
+                expect(Prism.highlight.calledWithExactly('return;', Prism.languages.javascript))
+                  .to.equal(true);
+              });
+
+              test('highlights only when code is set', function() {
+                expect(el.highlighted).to.equal(undefined);
+                el.code = null;
+                expect(el.highlighted).to.equal(undefined);
+                expect(Prism.highlight.callCount).to.equal(0);
+                el.code = 'return;';
+                expect(Prism.highlight.callCount).to.equal(1);
               });
           });
       });


### PR DESCRIPTION
Fixes #24 by exposing the highlighter functionality to data-binding and
programatic use.

Also now checks that the host exists before dealing with event listeners.

I have left `_highlight` named as it is for backwards-compatibility as some people may still be calling it directly.
