### PR TITLE
Add event when highlight event listener is registered

### DIFF
--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -15,8 +15,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 Syntax highlighting via [Prism](http://prismjs.com/).
 
 Place a `<prism-highlighter>` in your document, preferably as a direct child of
-`<body>`. It will listen for `syntax-highlight` events on its parent element,
+`<body>`. 
+
+It will listen for `syntax-highlight` events on its parent element,
 and annotate the code being provided via that event.
+
+a `prism-highlighter-highlight-event-registered` event will be fired when the event listener is registered on the page.
 
 The `syntax-highlight` event's detail is expected to have a `code` property
 containing the source to highlight. The event detail can optionally contain a

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -17,10 +17,21 @@ Syntax highlighting via [Prism](http://prismjs.com/).
 Place a `<prism-highlighter>` in your document, preferably as a direct child of
 `<body>`. 
 
+For shadow Dom support, make sure to import the html file with the theme:
+
+```
+<link rel="import" href="bower_components/prism-element/prism-theme-default.html">
+```
+and include the call the style:
+
+```
+<style is="custom-style" include="prism-theme-default"></style>
+```
+
 It will listen for `syntax-highlight` events on its parent element,
 and annotate the code being provided via that event.
 
-a `prism-highlighter-highlight-event-registered` event will be fired when the event listener is registered on the page.
+A `prism-highlighter-highlight-event-registered` event will be fired when the event listener is registered on the page.
 
 The `syntax-highlight` event's detail is expected to have a `code` property
 containing the source to highlight. The event detail can optionally contain a

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -44,6 +44,7 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
 
     attached: function() {
       (this.parentElement || this.parentNode.host).addEventListener(HIGHLIGHT_EVENT, this._handler);
+      this.fire('prism-highlighter-highlight-event-registered');
     },
 
     detached: function() {

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -41,7 +41,12 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
     ready: function() {
       this._handler = this._highlight.bind(this);
     },
-
+/**
+* Fired right after the syntax-highlight event listener is registered on the page.
+* this event signifies the prism-element is ready to intercept any highlight events.
+*
+* @event prism-highlighter-highlight-event-registered
+*/
     attached: function() {
       (this.parentElement || this.parentNode.host).addEventListener(HIGHLIGHT_EVENT, this._handler);
       this.fire('prism-highlighter-highlight-event-registered');

--- a/prism-highlighter.html
+++ b/prism-highlighter.html
@@ -15,8 +15,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 Syntax highlighting via [Prism](http://prismjs.com/).
 
 Place a `<prism-highlighter>` in your document, preferably as a direct child of
-`<body>`. It will listen for `syntax-highlight` events on its parent element,
+`<body>`. 
+
+For shadow Dom support, make sure to import the html file with the theme:
+
+```
+<link rel="import" href="bower_components/prism-element/prism-theme-default.html">
+```
+and include the call the style:
+
+```
+<style is="custom-style" include="prism-theme-default"></style>
+```
+
+It will listen for `syntax-highlight` events on its parent element,
 and annotate the code being provided via that event.
+
+A `prism-highlighter-highlight-event-registered` event will be fired when the event listener is registered on the page.
 
 The `syntax-highlight` event's detail is expected to have a `code` property
 containing the source to highlight. The event detail can optionally contain a
@@ -41,9 +56,15 @@ This flow is supported by [`<marked-element>`](https://github.com/PolymerElement
     ready: function() {
       this._handler = this._highlight.bind(this);
     },
-
+/**
+* Fired right after the syntax-highlight event listener is registered on the page.
+* this event signifies the prism-element is ready to intercept any highlight events.
+*
+* @event prism-highlighter-highlight-event-registered
+*/
     attached: function() {
       (this.parentElement || this.parentNode.host).addEventListener(HIGHLIGHT_EVENT, this._handler);
+      this.fire('prism-highlighter-highlight-event-registered');
     },
 
     detached: function() {

--- a/test/prism-element.html
+++ b/test/prism-element.html
@@ -155,6 +155,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               });
           });
       });
+      
+  suite('Prism Highlighter fires a "prism-highlighter-highlight-event-registered" event ', function() {
+    var eventObj;
+
+    suiteSetup(function(){
+      document.addEventListener('prism-highlighter-highlight-event-registered',function(evt){
+        eventObj = evt.detail;
+      });
+    });
+
+    test('impSVG fixture is created', function() {
+      assert.isDefined(eventObj, 'event is defined');
+    });
+  });
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fix #26 

@arthurevans 

If you place prism highlighter in another component, there's no way to know when the highlight event listener is registered, resulting in a possible race condition - highlight events being sent out before the event listener is even registered.

By firing a (prism-highlighter-highlight-event-registered) event after the listener is registered, the host can listen for the fired event, and act accordingly.
