### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/prism-highlighter.js
+++ b/prism-highlighter.js
@@ -34,6 +34,7 @@ This flow is supported by
 */
 Polymer({
   is: 'prism-highlighter',
+  _template: null,
 
   properties: {
     /**


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336